### PR TITLE
Selinux

### DIFF
--- a/selinux/README.md
+++ b/selinux/README.md
@@ -1,0 +1,9 @@
+# SELinux
+
+Policies to help manage and configure SELinux.
+
+## Contents
+
+* **selinux.cf**: Main selinux bundles (mode, booleans)
+* **secompile**: CFEngine3 module to list and compile selinux policy files
+

--- a/selinux/secompile
+++ b/selinux/secompile
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+export PATH="/usr/bin:/usr/sbin:/bin:/sbin"
+umask 077
+
+progname="$(basename $0)"
+
+mflag="false"
+qflag="false"
+compile="false"
+src=""
+
+_usage()
+{
+    cat <<EOF
+usage: $progname [-hmq] [ -f /policy/file ]
+
+Query or build/install selinux policy packages
+ -h : Shows this help
+ -m : Module mode; used when running from CFEngine (implies -q)
+ -q : Quiet mode
+ -f : Takes a policy file as an argument.
+      If given, this enables policy-build mode.
+      If absent, the queries and returns all installed SELinux modules
+
+EOF
+
+    exit $1
+}
+
+_query()
+{
+    local tmp="$(mktemp /tmp/secompile.XXXXXXXX)"
+    trap "rm $tmp" EXIT
+
+    if ! semodule -l >"$tmp"; then
+        $mflag && echo "+secompile_query_fail"
+        $qflag || echo "ERROR: semodule -l failed" 1>&2
+        return 1
+    fi
+
+    if $mflag; then
+        echo -n "%semodules=[$(awk '{print "\""$1"\"";}' < $tmp | tr '\n' ,)"
+        echo "]"
+        echo "+secompile_query_success"
+    else
+        awk '{print $1;}' < $tmp
+        $qflag || echo "+ Successfully listed SELinux modules"
+    fi
+
+    rm $tmp
+    trap - EXIT
+    return 0
+}
+
+_compile()
+{
+    if [[ ! -f "$src" || ! -r "$src" ]]; then
+        $mflag && echo "+secompile_compile_fail"
+        $qflag || echo "ERROR: source file $src does not exist or isn't readable" 1>&2
+        return 1
+    fi
+
+    local base="$(basename $src | sed -re 's/\.te$//')"
+    local mod="/tmp/${base}.mod"
+    local pp="/tmp/${base}.pp"
+
+    if ! checkmodule -M -m -o "$mod" "$src" >/dev/null; then
+        $mflag && echo "+secompile_compile_fail"
+        $qflag || echo "ERROR: checkmodule failed" 1>&2
+        return 1
+    fi
+
+    if ! semodule_package -o "$pp" -m "$mod" >/dev/null; then
+        $mflag && echo "+secompile_compile_fail"
+        $qflag || echo "ERROR: semodule_package failed" 1>&2
+        return 1
+    fi
+
+    if ! semodule -i "$pp" >/dev/null; then
+        $mflag && echo "+secompile_compile_fail"
+        $qflag || echo "ERROR: semodule -i failed" 1>&2
+        return 1
+    fi
+
+    $mflag && echo "+secompile_compile_success"
+    $qflag || echo "+ Successfully compiled SELinux policy $src"
+
+    return 0
+}
+
+while getopts "f:hmq" _opt; do
+    case "$_opt" in
+        "h")
+            _usage 0
+        ;;
+        "m")
+            mflag="true"
+            qflag="true"
+        ;;
+        "q")
+            qflag="true"
+        ;;
+        "f")
+            src="$OPTARG"
+            compile="true"
+        ;;
+        "*")
+            _usage 1
+        ;;
+    esac
+done
+
+$compile || { _query; exit; }
+$compile && { _compile; exit; }

--- a/selinux/secompile
+++ b/selinux/secompile
@@ -21,7 +21,8 @@ Query or build/install selinux policy packages
  -q : Quiet mode
  -f : Takes a policy file as an argument.
       If given, this enables policy-build mode.
-      If absent, the queries and returns all installed SELinux modules
+      If absent, queries and returns all installed SELinux modules (as a data
+      list, if -m is used)
 
 EOF
 

--- a/selinux/secompile
+++ b/selinux/secompile
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-export PATH="/usr/bin:/usr/sbin:/bin:/sbin"
+typeset -x PATH="/usr/bin:/usr/sbin:/bin:/sbin"
 umask 077
 
-progname="$(basename $0)"
+typeset progname="$(basename $0)"
 
-mflag="false"
-qflag="false"
-compile="false"
-src=""
+typeset mflag="false"
+typeset qflag="false"
+typeset compile="false"
+typeset src=""
 
 _usage()
 {

--- a/selinux/selinux.cf
+++ b/selinux/selinux.cf
@@ -1,0 +1,43 @@
+##########################################################################
+# vim:syntax=cf3:tabstop=2:shiftwidth=2:softtabstop=2:smarttab:expandtab
+#
+# Library file for tuning selinux policies
+#
+
+body file control
+{
+  inputs => {
+              "$(sys.libdir)/stdlib.cf",
+            };
+  namespace => "selinux";
+}
+
+bundle agent boolean(bool, state)
+{
+  vars:
+    redhat::
+      "getsebool"      string => "/usr/sbin/getsebool";
+      "setsebool"      string => "/usr/sbin/setsebool";
+      "selinuxenabled" string => "/usr/sbin/selinuxenabled";
+
+      "selinux_enabled" string => and(returnszero("$(selinuxenabled)", "noshell"));
+
+      "selinux_$(bool)"
+        string     => execresult("$(getsebool) $(bool)", "useshell"),
+        ifvarclass => "$(selinux_enabled)";
+
+  classes:
+    redhat::
+      "$(bool)_set" expression => regcmp("$(bool) .* $(state)$", "$(selinux_$(bool))");
+
+  commands:
+    redhat::
+      "$(setsebool) -P $(bool) $(state)"
+        ifvarclass => and("$(selinux_enabled)", not("$(bool)_set")),
+        classes    => default:if_ok("$(bool)_set");
+
+  reports:
+    inform_mode::
+      "Set selinux boolean $(bool) => $(state)"
+        ifvarclass => "$(bool)_set";
+}

--- a/selinux/selinux.cf
+++ b/selinux/selinux.cf
@@ -12,6 +12,71 @@ body file control
   namespace => "selinux";
 }
 
+bundle agent status(mode)
+{
+  vars:
+    any::
+      "modes" slist => {
+                        "enforcing",
+                        "permissive",
+                        "disabled",
+                       };
+
+    redhat::
+      "getenforce"     string => "/usr/sbin/getenforce";
+      "setenforce"     string => "/usr/sbin/setenforce";
+      "selinuxenabled" string => "/usr/sbin/selinuxenabled";
+
+      "selinux_config"
+        string => "/etc/selinux/config";
+
+      "selinux_enmode"
+        string => execresult("$(getenforce)", "noshell");
+
+      "v[SELINUX]"    # Values to set in the form v[LHS]=RHS
+        string => "$(mode)";
+
+  classes:
+    any::
+      "to_enforcing"      expression => strcmp("$(mode)", "enforcing");
+      "selinux_enforcing" expression => strcmp("$(selinux_enmode)", "Enforcing");
+      "selinux_enabled"   expression => returnszero("$(selinuxenabled)", "noshell");
+      "mode_valid"        expression => some("$(mode)", "modes");
+
+  files:
+    redhat::
+      "$(selinux_config)"
+        handle     => "selinux_status_files_config",
+        comment    => "Set SELinux mode in the config file",
+        edit_line  => default:set_line_based("$(this.namespace):$(this.bundle).v", "=", "\s*=\s*", ".*", "\s*#\s*"),
+        perms      => default:system_owned("0644"),
+        classes    => default:scoped_classes_generic("bundle", "selinux_config"),
+        ifvarclass => and(isvariable("selinux_config"), "mode_valid");
+
+  commands:
+    redhat::
+      "$(setenforce) 0"
+        comment    => "Disable SELinux",
+        classes    => default:if_repaired("disabled_enforcement"),
+        ifvarclass => and("selinux_enforcing", "selinux_enabled", not("to_enforcing"));
+
+      "$(setenforce) 1"
+        comment    => "Enable SELinux",
+        classes    => default:if_repaired("enabled_enforcement"),
+        ifvarclass => and(not("selinux_enforcing"), "selinux_enabled", "to_enforcing");
+
+  reports:
+    inform_mode::
+      "SELinux configuration file mode = $(mode)"
+        ifvarclass => "selinux_config_ok";
+
+      "SELinux set to permissive mode"
+        ifvarclass => "disabled_enforcement";
+
+      "SELinux set to enforcing mode"
+        ifvarclass => "enabled_enforcement";
+}
+
 bundle agent boolean(bool, state)
 {
   vars:


### PR DESCRIPTION
# SELinux Tools

Some policy and a module for basic _SELinux_ handling.
## selinux.cf

This is a standard policy file, enclosed in the _selinux_ namespace. It has two bundles:
1. **status(_mode_)**: This sets the overall selinux state of the system, and **mode** should be one of _enforcing_, _permissive_, or _disabled_. Of course, disabling requires a reboot to fully take effect.
2. **boolean(_bool_, _state_)**: Sets a particular selinux boolean value, **bool**, to state, **state**. **state** should be one of _on_ or _off_. Example: _selinux:boolean("secure_mode", "on")_.
## secompile

This is a cfengine module which lists and compiles custom selinux policy files. It currently only supports basic policy modules (not, e.g. including custom file-contexts, etc.). It's help output:

> usage: secompile [-hmq] [ -f /policy/file ]
> 
> Query or build/install selinux policy packages
>  -h : Shows this help
>  -m : Module mode; used when running from CFEngine (implies -q)
>  -q : Quiet mode
>  -f : Takes a policy file as an argument. If given, this enables policy-build mode. If absent, queries and returns all installed SELinux modules (as a data list, when -m is used)
